### PR TITLE
Add export capabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ dmypy.json
 .vscode/
 .idea/
 *.DS_Store
+
+# Developer files
+dev/

--- a/docs/user-guide/load-phenopacket-store.rst
+++ b/docs/user-guide/load-phenopacket-store.rst
@@ -37,3 +37,58 @@ We can load phenopackets for a cohort name (e.g. *SUOX*). The phenopackets are l
 and we collect them into a list. 
 
 We loaded 35 phenopackets!
+
+
+Export a phenopacket cohort
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Phenopackets of a cohort can easily be exported into a directory for further processing.
+The export is implemented on the :class:`~ppktstore.model.CohortInfo` class of the Phenopacket Store API:
+
+>>> outdir = "dev/SUOX"
+>>> with registry.open_phenopacket_store(release="0.1.18") as ps:
+...     cohort = ps.cohort_for_name("SUOX")
+...     cohort.export_phenopackets_to_directory(outdir)
+
+We open Phenopacket Store and get the :class:`~ppktstore.model.CohortInfo` for the *SUOX* cohort.
+Then we export the phenopackets into a directory (e.g. ``"dev/SUOX"``)
+
+We can check if the phenopackets were exported:
+
+>>> import os
+>>> paths = sorted(os.listdir(outdir))
+>>> paths[:5]  # doctest: +NORMALIZE_WHITESPACE
+['PMID_36303223_individual_10_PMID_12112661.json',
+ 'PMID_36303223_individual_11_PMID_12112661.json',
+ 'PMID_36303223_individual_12_PMID_12112661.json',
+ 'PMID_36303223_individual_13_PMID_12112661.json',
+ 'PMID_36303223_individual_14_PMID_11825068.json']
+
+.. Clean up the folder
+.. doctest::
+  :hide:
+
+  >>> for fp in os.listdir(outdir): os.remove(os.path.join(outdir, fp))
+  >>> os.rmdir(outdir)
+
+By default, the phenopackets are stored in JSON format. However, Protobuf wire format is also supported:
+
+>>> with registry.open_phenopacket_store(release="0.1.18") as ps:
+...     cohort = ps.cohort_for_name("SUOX")
+...     cohort.export_phenopackets_to_directory(outdir, format="pb")
+>>> sorted(os.listdir(outdir))[:5] # doctest: +NORMALIZE_WHITESPACE
+['PMID_36303223_individual_10_PMID_12112661.pb',
+ 'PMID_36303223_individual_11_PMID_12112661.pb',
+ 'PMID_36303223_individual_12_PMID_12112661.pb',
+ 'PMID_36303223_individual_13_PMID_12112661.pb',
+ 'PMID_36303223_individual_14_PMID_11825068.pb']
+
+We use the ``format`` option to export phenopackets as Protobuf files.
+
+
+.. Clean up the folder
+.. doctest::
+  :hide:
+
+  >>> for fp in os.listdir(outdir): os.remove(os.path.join(outdir, fp))
+  >>> os.rmdir(outdir)

--- a/src/ppktstore/__main__.py
+++ b/src/ppktstore/__main__.py
@@ -1,9 +1,10 @@
 import argparse
 import logging
+import pathlib
+import os
 import sys
 
 import ppktstore
-import ppktstore.release
 
 
 def main(argv) -> int:
@@ -56,7 +57,7 @@ def main(argv) -> int:
 
     # #################### ------------- `report` -------------- ####################
     report = subparsers.add_parser("report", help="Generate reports")
-    subparsers_report = report.add_subparsers(dest="report_command")
+    subparsers_report = report.add_subparsers(dest="subcommand")
 
     parser_collections = subparsers_report.add_parser(
         "collections", help="Generate collections report"
@@ -71,6 +72,45 @@ def main(argv) -> int:
     )
     parser_collections.add_argument(
         "--output", help="where to generate the collections report"
+    )
+
+    # #################### ------------- `export` -------------- ####################
+
+    parser_export = subparsers.add_parser(
+        "export", help="Export a phenopackets, cohorts, or families"
+    )
+    subparsers_export = parser_export.add_subparsers(dest="subcommand")
+
+    # #################### ------------- `export | phenopackets` ####################
+    parser_export_phenopackets = subparsers_export.add_parser(
+        "phenopackets",
+        help="export phenopackets from phenopacket store",
+    )
+    parser_export_phenopackets.add_argument(
+        "-r",
+        "--release",
+        default=None,
+        help="phenopacket store release tag (default: latest)",
+    )
+    parser_export_phenopackets.add_argument(
+        "-f",
+        "--format",
+        type=str,
+        default="json",
+        choices=("json", "pb"),
+        help="phenopacket file format (default: json)",
+    )
+    parser_export_phenopackets.add_argument(
+        "-o",
+        "--outdir",
+        type=pathlib.Path,
+        default=pathlib.Path(os.getcwd()),
+        help="path to directory where to export",
+    )
+    parser_export_phenopackets.add_argument(
+        "cohort",
+        type=str,
+        help="name of the cohort to export",
     )
 
     if len(argv) == 0:
@@ -106,7 +146,7 @@ def main(argv) -> int:
             logger=logger,
         )
     elif args.command == "report":
-        if args.report_command == "collections":
+        if args.subcommand == "collections":
             from ppktstore.release.report import generate_collections_report
 
             return generate_collections_report(
@@ -117,6 +157,33 @@ def main(argv) -> int:
             )
         else:
             report.print_help()
+            return 1
+    elif args.command == "export":
+        if args.subcommand == "phenopackets":
+            from ppktstore.registry import configure_phenopacket_registry
+
+            if args.format not in ("json", "pb"):
+                logger.error(
+                    "format must be one of ('json', 'pb') but was %s", args.format
+                )
+                return 1
+
+            release = getattr(args, "release") if hasattr(args, "release") else None
+            registry = configure_phenopacket_registry()
+
+            with registry.open_phenopacket_store(release=release) as ps:
+                try:
+                    ps.cohort_for_name(args.cohort).export_phenopackets_to_directory(
+                        path=args.outdir,
+                        format=args.format,
+                    )
+                except KeyError:
+                    logger.error(
+                        "Cohort %s was not found in phenopacket store", args.cohort
+                    )
+            return 0
+        else:
+            parser.print_help()
             return 1
     else:
         parser.print_help()

--- a/src/ppktstore/model.py
+++ b/src/ppktstore/model.py
@@ -2,6 +2,7 @@ import abc
 import dataclasses
 import os
 import pathlib
+import re
 import typing
 import zipfile
 
@@ -12,6 +13,7 @@ from phenopackets.schema.v2.phenopackets_pb2 import Phenopacket
 
 from ._zip_util import relative_to
 
+_FILEFORMAT_SUFFIXES = re.compile(r"\.(json|pb)$")
 
 class PhenopacketInfo(metaclass=abc.ABCMeta):
     """
@@ -50,7 +52,7 @@ class EagerPhenopacketInfo(PhenopacketInfo):
         """
         pp = Parse(pp_path.read_text(), Phenopacket())
         return EagerPhenopacketInfo.from_phenopacket(path, pp)
-    
+
     @staticmethod
     def from_phenopacket(
         path: str,
@@ -123,6 +125,42 @@ class CohortInfo:
         """
         return map(lambda pi: pi.phenopacket, self.phenopackets)
 
+    def export_phenopackets_to_directory(
+        self,
+        path: typing.Union[pathlib.Path, str],
+        format: typing.Literal["pb", "json"] = "json",
+    ):
+        """
+        Export the phenopackets into a directory.
+
+        Each phenopacket is exported into a single file.
+        The directory is created if it does not exist.
+
+        :param path: path to the output directory.
+        :param format: phenopacket file format, one of ``{"pb", "json"}`` for Protobuf and JSON format, respectively.
+        :raises ValueError: if `output` does not point to a directory.
+        """
+        if not os.path.exists(path):
+            os.makedirs(path, exist_ok=True)
+        
+        if not os.path.isdir(path):
+            raise ValueError(f"output {path} does is not a directory")
+        
+        match format:
+            case "json":
+                from google.protobuf.json_format import MessageToJson
+                for pi in self.phenopackets:
+                    fpath_out = os.path.join(path, f"{pi.path}.json")
+                    with open(fpath_out, "w") as fh:
+                        fh.write(MessageToJson(pi.phenopacket))
+            case "pb":
+                for pi in self.phenopackets:
+                    fpath_out = os.path.join(path, f"{pi.path}.pb")
+                    with open(fpath_out, "wb") as fh:
+                        fh.write(pi.phenopacket.SerializeToString())
+            case _:
+                raise ValueError(f"Invalid format {format}")
+
     def __len__(self) -> int:
         return len(self.phenopackets)
 
@@ -150,11 +188,11 @@ class PhenopacketStore(metaclass=abc.ABCMeta):
         ^^^^^^^^
 
         The phenopackets can be loaded in an *eager* or *lazy* fashion.
-        
+
         The `'eager'` strategy loads *all* phenopackets during the execution
         of this function. This may do more work than necessary,
         especially if only several cohorts are needed.
-        
+
         The `'lazy'` strategy only scans the ZIP for phenopackets
         and the actual parsing is done on demand, when accessing
         the :attr:`PhenopacketInfo.phenopacket` property.
@@ -188,12 +226,12 @@ class PhenopacketStore(metaclass=abc.ABCMeta):
             entry_path = zipfile.Path(zip_file, at=entry.filename)
             if entry_path.is_dir():
                 entry_parent = relative_to(root, entry_path.parent)
-                if entry_parent in ('', '.'):
+                if entry_parent in ("", "."):
                     name = entry_path.name
                 else:
                     cohort_name = entry_path.name
                     cohort2path[cohort_name] = entry_path
-            elif entry_path.is_file() and entry_path.name.endswith('.json'):
+            elif entry_path.is_file() and entry_path.name.endswith(".json"):
                 # This SHOULD be a phenopacket!
                 cohort = entry_path.parent.name  # type: ignore
                 cohort2pp_paths[cohort].append(entry_path)
@@ -202,18 +240,15 @@ class PhenopacketStore(metaclass=abc.ABCMeta):
         cohorts = []
         for cohort, cohort_path in cohort2path.items():
             if cohort in cohort2pp_paths:
-                # cohort_path.relative_to(root)
-                at = relative_to(root, cohort_path)
+                at = relative_to(cohort_path, root)
                 rel_cohort_path = zipfile.Path(
-                    zip_file, at=at,
+                    zip_file,
+                    at=at,
                 )
                 pp_infos = []
                 for pp_path in cohort2pp_paths[cohort]:
-                    # cohort_path_str = str(cohort_path)
-                    # pp_path_str = str(pp_path)
-                    # path = pp_path_str.replace(cohort_path_str, '')
-                    path = relative_to(cohort_path, pp_path)
-                    # path = pp_path.relative_to(cohort_path)
+                    path = relative_to(pp_path, cohort_path)
+                    path = re.sub(_FILEFORMAT_SUFFIXES, "", path)
                     if strategy == "eager":
                         pi = EagerPhenopacketInfo.from_path(path, pp_path)
                     elif strategy == "lazy":
@@ -268,9 +303,10 @@ class PhenopacketStore(metaclass=abc.ABCMeta):
                     for filename in os.listdir(cohort_path):
                         if filename.endswith(".json"):
                             filepath = cohort_path.joinpath(filename)
+                            path = re.sub(_FILEFORMAT_SUFFIXES, "", filename)
                             pp = Parse(filepath.read_text(), Phenopacket())
                             pi = EagerPhenopacketInfo(
-                                path=filename,
+                                path=path,
                                 phenopacket=pp,
                             )
                             pp_infos.append(pi)
@@ -376,7 +412,6 @@ class PhenopacketStore(metaclass=abc.ABCMeta):
 
 
 class DefaultPhenopacketStore(PhenopacketStore):
-
     def __init__(
         self,
         name: str,

--- a/src/ppktstore/release/archive/_archiver.py
+++ b/src/ppktstore/release/archive/_archiver.py
@@ -190,7 +190,7 @@ class PhenopacketStoreArchiver:
             # original files
             cohort_path = store.path.joinpath(cohort_info.path)
             for pp_info in cohort_info.phenopackets:
-                pp_path = cohort_path.joinpath(pp_info.path)
+                pp_path = cohort_path.joinpath(f"{pp_info.path}.json")
                 shutil.copy(pp_path, temp_cohort_dir)
                 n_copied_files += 1
         return n_copied_files

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,9 @@
 import os
+import zipfile
 
 import pytest
+
+from ppktstore.model import PhenopacketStore
 
 
 @pytest.fixture(scope="session")
@@ -21,3 +24,13 @@ def fpath_ps_release_zip(
     fpath_test_data: str,
 ) -> str:
     return os.path.join(fpath_test_data, "test_get_store_zip0.zip")
+
+
+@pytest.fixture(scope="session")
+def phenopacket_store(
+    fpath_ps_release_zip: str,
+):
+    with zipfile.ZipFile(fpath_ps_release_zip) as zip_file:
+        yield PhenopacketStore.from_release_zip(
+            zip_file=zip_file,
+        )

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,10 +1,72 @@
+import os
+import pathlib
 import zipfile
+
+import pytest
 
 from ppktstore.model import PhenopacketStore, CohortInfo
 
 
-class TestPhenopacketStore:
+class TestCohortInfo:
+    @pytest.fixture(scope="class")
+    def cohort_info(
+        self,
+        phenopacket_store: PhenopacketStore,
+    ) -> CohortInfo:
+        return phenopacket_store.cohort_for_name("AXIN1")
 
+    def test_export_phenopackets_to_directory_pb(
+        self,
+        cohort_info: CohortInfo,
+        tmpdir: pathlib.Path,
+    ):
+        before = tuple(os.listdir(tmpdir))
+        assert len(before) == 0
+
+        cohort_info.export_phenopackets_to_directory(
+            tmpdir,
+            format="pb",
+        )
+
+        after = sorted(os.listdir(tmpdir))
+
+        assert after == [
+            "PMID_37582359_F1-II-1.pb",
+            "PMID_37582359_F1-II-4.pb",
+            "PMID_37582359_F2-III-2.pb",
+            "PMID_37582359_F3-III-1.pb",
+            "PMID_37582359_F4-III-1.pb",
+            "PMID_37582359_F4-III-3.pb",
+            "PMID_37582359_F4-III-4.pb",
+        ]
+
+    def test_export_phenopackets_to_directory_json(
+        self,
+        cohort_info: CohortInfo,
+        tmpdir: pathlib.Path,
+    ):
+        before = tuple(os.listdir(tmpdir))
+        assert len(before) == 0
+
+        cohort_info.export_phenopackets_to_directory(
+            tmpdir,
+            format="json",
+        )
+
+        after = sorted(os.listdir(tmpdir))
+
+        assert after == [
+            "PMID_37582359_F1-II-1.json",
+            "PMID_37582359_F1-II-4.json",
+            "PMID_37582359_F2-III-2.json",
+            "PMID_37582359_F3-III-1.json",
+            "PMID_37582359_F4-III-1.json",
+            "PMID_37582359_F4-III-3.json",
+            "PMID_37582359_F4-III-4.json",
+        ]
+
+
+class TestPhenopacketStore:
     def test_from_notebook_dir(
         self,
         fpath_nb_dir: str,
@@ -47,12 +109,19 @@ def check_aagab_cohort_specs(
     # on whether Phenopacket store is loaded from a notebook folder or from a release ZIP.
     assert len(cohort) == 3
 
-    pp_ids = set(pp_info.phenopacket.id for pp_info in cohort.phenopackets)
-    assert pp_ids == {
+    pp_paths = sorted(pp_info.path for pp_info in cohort.phenopackets)
+    assert pp_paths == [
+        "PMID_28239884_Family1proband",
+        "PMID_28239884_Family2proband",
+        "PMID_28239884_Family3proband",
+    ]
+
+    pp_ids = sorted(pp_info.phenopacket.id for pp_info in cohort.phenopackets)
+    assert pp_ids == [
         "PMID_28239884_Family_1_proband",
         "PMID_28239884_Family_2_proband",
         "PMID_28239884_Family_3_proband",
-    }
+    ]
 
 
 def check_axin1_cohort_specs(
@@ -63,13 +132,24 @@ def check_axin1_cohort_specs(
     # on whether Phenopacket store is loaded from a notebook folder or from a release ZIP.
     assert len(cohort) == 7
 
-    pp_ids = set(pp_info.phenopacket.id for pp_info in cohort.phenopackets)
-    assert pp_ids == {
+    pp_paths = sorted(pp_info.path for pp_info in cohort.phenopackets)
+    assert pp_paths == [
+        "PMID_37582359_F1-II-1",
         "PMID_37582359_F1-II-4",
         "PMID_37582359_F2-III-2",
-        "PMID_37582359_F4-III-3",
-        "PMID_37582359_F4-III-4",
-        "PMID_37582359_F1-II-1",
         "PMID_37582359_F3-III-1",
         "PMID_37582359_F4-III-1",
-    }
+        "PMID_37582359_F4-III-3",
+        "PMID_37582359_F4-III-4",
+    ]
+
+    pp_ids = sorted(pp_info.phenopacket.id for pp_info in cohort.phenopackets)
+    assert pp_ids == [
+        "PMID_37582359_F1-II-1",
+        "PMID_37582359_F1-II-4",
+        "PMID_37582359_F2-III-2",
+        "PMID_37582359_F3-III-1",
+        "PMID_37582359_F4-III-1",
+        "PMID_37582359_F4-III-3",
+        "PMID_37582359_F4-III-4",
+    ]


### PR DESCRIPTION
Allow exporting phenopackets of a cohort into a directory.

Either JSON or Protobuf formats are supported.

The export can also be performed from CLI via `ppktstore export phenopackets` command.